### PR TITLE
Allow any connections when creating the postgress db

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -62,7 +62,7 @@ func Example_postgres() {
 	}
 
 	// dktest.Run() should be used within a test
-	dktest.Run(&testing.T{}, dockerImageName, dktest.Options{PortRequired: true, ReadyFunc: readyFunc},
+	dktest.Run(&testing.T{}, dockerImageName, dktest.Options{PortRequired: true, ReadyFunc: readyFunc, Env: map[string]string{"POSTGRES_HOST_AUTH_METHOD": "trust"}},
 		func(t *testing.T, c dktest.ContainerInfo) {
 			ip, port, err := c.FirstPort()
 			if err != nil {


### PR DESCRIPTION
Hi,

I'm not sure if this will fix the issue that you were running into with your build, but i couldn't get the example postgres test to work without the addition of `POSTGRES_HOST_AUTH_METHOD: trust`. Without that the docker container stopped with:

```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".

       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
       connections without a password. This is *not* recommended.

       See PostgreSQL documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```

Hope it resolves the issue you were seeing and get that build merged in 🙂 