### PR TITLE
Add Volumes, Mounts and Hostname options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
 env:
   global:
     - GO111MODULE=on
-    - GOLANGCI_LINT_VERSION=v1.31.0
+    - GOLANGCI_LINT_VERSION=v1.43.0
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ docker container prune --filter label=dktest
 * [x] Support multiple ports in `ContainerInfo`
 * [ ] Use non-default network
 * [ ] Add more `Options`
-  * [ ] Volume mounts
+  * [x] Volume mounts
   * [ ] Network config
 * [ ] Support testing against multiple containers. It can be faked for now by nested/recursive `Run()` calls but that serializes the containers' startup time.
 

--- a/dktest.go
+++ b/dktest.go
@@ -6,9 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
-)
 
-import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -66,6 +64,7 @@ func runImage(ctx context.Context, lgr logger, dc client.ContainerAPIClient, img
 		Env:        opts.env(),
 		Entrypoint: opts.Entrypoint,
 		Cmd:        opts.Cmd,
+		Volumes:    opts.volumes(),
 	}, &container.HostConfig{
 		PublishAllPorts: true,
 		PortBindings:    opts.PortBindings,

--- a/dktest.go
+++ b/dktest.go
@@ -65,6 +65,7 @@ func runImage(ctx context.Context, lgr logger, dc client.ContainerAPIClient, img
 		Entrypoint: opts.Entrypoint,
 		Cmd:        opts.Cmd,
 		Volumes:    opts.volumes(),
+		Hostname:   opts.Hostname,
 	}, &container.HostConfig{
 		PublishAllPorts: true,
 		PortBindings:    opts.PortBindings,

--- a/dktest.go
+++ b/dktest.go
@@ -69,6 +69,7 @@ func runImage(ctx context.Context, lgr logger, dc client.ContainerAPIClient, img
 		PublishAllPorts: true,
 		PortBindings:    opts.PortBindings,
 		ShmSize:         opts.ShmSize,
+		Mounts:          opts.Mounts,
 	}, &network.NetworkingConfig{},
 		nil,
 		c.Name)

--- a/options.go
+++ b/options.go
@@ -31,6 +31,7 @@ type Options struct {
 	ShmSize      int64
 	Volumes      []string
 	Mounts       []mount.Mount
+	Hostname     string
 }
 
 func (o *Options) init() {

--- a/options.go
+++ b/options.go
@@ -3,9 +3,7 @@ package dktest
 import (
 	"context"
 	"time"
-)
 
-import (
 	"github.com/docker/go-connections/nat"
 )
 
@@ -30,6 +28,7 @@ type Options struct {
 	LogStdout    bool
 	LogStderr    bool
 	ShmSize      int64
+	Volumes      []string
 }
 
 func (o *Options) init() {
@@ -45,6 +44,14 @@ func (o *Options) init() {
 	if o.CleanupTimeout <= 0 {
 		o.CleanupTimeout = DefaultCleanupTimeout
 	}
+}
+
+func (o *Options) volumes() map[string]struct{} {
+	volumes := make(map[string]struct{})
+	for _, v := range o.Volumes {
+		volumes[v] = struct{}{}
+	}
+	return volumes
 }
 
 func (o *Options) env() []string {

--- a/options.go
+++ b/options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/go-connections/nat"
 )
 
@@ -29,6 +30,7 @@ type Options struct {
 	LogStderr    bool
 	ShmSize      int64
 	Volumes      []string
+	Mounts       []mount.Mount
 }
 
 func (o *Options) init() {


### PR DESCRIPTION
Accept list of volumes mapping in `[]string` and pass it to ContainerCreate as `map[string]struct{}`. Mounts accepted as docker `[]mount.Mount` type.

P.s. Imports was merged by goimports.