### PR TITLE
Add option for specifying platform of docker image

### DIFF
--- a/dktest.go
+++ b/dktest.go
@@ -30,11 +30,11 @@ const (
 	label = "dktest"
 )
 
-func pullImage(ctx context.Context, lgr logger, dc client.ImageAPIClient, imgName string) error {
+func pullImage(ctx context.Context, lgr logger, dc client.ImageAPIClient, imgName, platform string) error {
 	lgr.Log("Pulling image:", imgName)
 	// lgr.Log(dc.ImageList(ctx, types.ImageListOptions{All: true}))
 
-	resp, err := dc.ImagePull(ctx, imgName, types.ImagePullOptions{})
+	resp, err := dc.ImagePull(ctx, imgName, types.ImagePullOptions{Platform: platform})
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func Run(t *testing.T, imgName string, opts Options, testFunc func(*testing.T, C
 	pullCtx, pullTimeoutCancelFunc := context.WithTimeout(context.Background(), opts.PullTimeout)
 	defer pullTimeoutCancelFunc()
 
-	if err := pullImage(pullCtx, t, dc, imgName); err != nil {
+	if err := pullImage(pullCtx, t, dc, imgName, opts.Platform); err != nil {
 		t.Fatal("Failed to pull image:", imgName, "error:", err)
 	}
 

--- a/dktest_internal_test.go
+++ b/dktest_internal_test.go
@@ -5,16 +5,11 @@ import (
 	"io"
 	"testing"
 	"time"
-)
 
-import (
+	"github.com/dhui/dktest/mockdockerclient"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
-)
-
-import (
-	"github.com/dhui/dktest/mockdockerclient"
 )
 
 const (
@@ -50,7 +45,7 @@ func TestPullImage(t *testing.T) {
 		{name: "success", client: mockdockerclient.ImageAPIClient{
 			PullResp: mockdockerclient.MockReadCloser{MockReader: successReader}}, expectErr: false},
 		{name: "with specific platform", client: mockdockerclient.ImageAPIClient{
-			PullResp: mockdockerclient.MockReadCloser{MockReader: successReader}, Platform: "linux/x86_64"},
+			PullResp: mockdockerclient.MockReadCloser{MockReader: successReader}},
 			platform: "linux/x86_64", expectErr: false},
 		{name: "pull error", client: mockdockerclient.ImageAPIClient{}, expectErr: true},
 		{name: "read error", client: mockdockerclient.ImageAPIClient{

--- a/dktest_internal_test.go
+++ b/dktest_internal_test.go
@@ -44,10 +44,14 @@ func TestPullImage(t *testing.T) {
 	testCases := []struct {
 		name      string
 		client    mockdockerclient.ImageAPIClient
+		platform  string
 		expectErr bool
 	}{
 		{name: "success", client: mockdockerclient.ImageAPIClient{
 			PullResp: mockdockerclient.MockReadCloser{MockReader: successReader}}, expectErr: false},
+		{name: "with specific platform", client: mockdockerclient.ImageAPIClient{
+			PullResp: mockdockerclient.MockReadCloser{MockReader: successReader}, Platform: "linux/x86_64"},
+			platform: "linux/x86_64", expectErr: false},
 		{name: "pull error", client: mockdockerclient.ImageAPIClient{}, expectErr: true},
 		{name: "read error", client: mockdockerclient.ImageAPIClient{
 			PullResp: mockdockerclient.MockReadCloser{
@@ -63,7 +67,7 @@ func TestPullImage(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := pullImage(ctx, t, &tc.client, imageName)
+			err := pullImage(ctx, t, &tc.client, imageName, tc.platform)
 			testErr(t, err, tc.expectErr)
 		})
 	}

--- a/mockdockerclient/image_api_client.go
+++ b/mockdockerclient/image_api_client.go
@@ -15,6 +15,7 @@ import (
 // ImageAPIClient is a mock implementation of the Docker's client.ImageAPIClient interface
 type ImageAPIClient struct {
 	PullResp io.ReadCloser
+	Platform string
 }
 
 // ImageBuild is a mock implementation of Docker's client.ImageAPIClient.ImageBuild()
@@ -83,8 +84,11 @@ func (c *ImageAPIClient) ImageLoad(context.Context, io.Reader, bool) (types.Imag
 }
 
 // ImagePull is a mock implementation of Docker's client.ImageAPIClient.ImagePull()
-func (c *ImageAPIClient) ImagePull(context.Context, string, types.ImagePullOptions) (io.ReadCloser, error) {
+func (c *ImageAPIClient) ImagePull(ctx context.Context, ref string, opts types.ImagePullOptions) (io.ReadCloser, error) {
 	if c.PullResp == nil {
+		return nil, Err
+	}
+	if c.Platform != opts.Platform {
 		return nil, Err
 	}
 	return c.PullResp, nil

--- a/mockdockerclient/image_api_client.go
+++ b/mockdockerclient/image_api_client.go
@@ -15,7 +15,6 @@ import (
 // ImageAPIClient is a mock implementation of the Docker's client.ImageAPIClient interface
 type ImageAPIClient struct {
 	PullResp io.ReadCloser
-	Platform string
 }
 
 // ImageBuild is a mock implementation of Docker's client.ImageAPIClient.ImageBuild()
@@ -84,11 +83,8 @@ func (c *ImageAPIClient) ImageLoad(context.Context, io.Reader, bool) (types.Imag
 }
 
 // ImagePull is a mock implementation of Docker's client.ImageAPIClient.ImagePull()
-func (c *ImageAPIClient) ImagePull(ctx context.Context, ref string, opts types.ImagePullOptions) (io.ReadCloser, error) {
+func (c *ImageAPIClient) ImagePull(context.Context, string, types.ImagePullOptions) (io.ReadCloser, error) {
 	if c.PullResp == nil {
-		return nil, Err
-	}
-	if c.Platform != opts.Platform {
 		return nil, Err
 	}
 	return c.PullResp, nil

--- a/options.go
+++ b/options.go
@@ -32,6 +32,8 @@ type Options struct {
 	Volumes      []string
 	Mounts       []mount.Mount
 	Hostname     string
+	// Platform specifies the platform of the docker image that is pulled.
+	Platform string
 }
 
 func (o *Options) init() {


### PR DESCRIPTION
Hi! 👋 Firstly, thank you this awesome package!

This PR adds an option for specifying the platform of the docker image that gets
pulled by the `Run` function. This option is useful for users with Apple M1 laptops
that need to pull an image that doesn't have support for the `linux/arm64` platform.
Instead, such users could pull the standard `linux/amd64` image and run it instead
(via Rosetta).