### PR TITLE
Add RunContext to run with context, and returns an error instead of using testing.T

### DIFF
--- a/dktest.go
+++ b/dktest.go
@@ -197,7 +197,7 @@ func RunContext(ctx context.Context, logger Logger, imgName string, opts Options
 		return fmt.Errorf("pull image: %v error: %w", imgName, err)
 	}
 
-	{
+	return func() error {
 		runCtx, runTimeoutCancelFunc := context.WithTimeout(ctx, opts.Timeout)
 		defer runTimeoutCancelFunc()
 
@@ -216,9 +216,9 @@ func RunContext(ctx context.Context, logger Logger, imgName string, opts Options
 				return fmt.Errorf("run test func: %w", err)
 			}
 		} else {
-			retErr = fmt.Errorf("wait for container to get ready before timing out: %v", c.String())
+			return fmt.Errorf("wait for container to get ready before timing out: %v", c.String())
 		}
-	}
 
-	return retErr
+		return nil
+	}()
 }

--- a/dktest.go
+++ b/dktest.go
@@ -2,6 +2,7 @@ package dktest
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -26,20 +27,11 @@ var (
 	DefaultCleanupTimeout = 15 * time.Second
 )
 
-// TestingT is a subset of `*testing.T`/`testing.TB` that is used by dktest.
-// This minimal interface allows it to be used when a `*testing.T` is not available
-// such as benchmarks, or TestMain.
-type TestingT interface {
-	Error(args ...interface{})
-	Fatal(args ...interface{})
-	Log(args ...interface{})
-}
-
 const (
 	label = "dktest"
 )
 
-func pullImage(ctx context.Context, lgr logger, dc client.ImageAPIClient, imgName, platform string) error {
+func pullImage(ctx context.Context, lgr Logger, dc client.ImageAPIClient, imgName, platform string) error {
 	lgr.Log("Pulling image:", imgName)
 	// lgr.Log(dc.ImageList(ctx, types.ImageListOptions{All: true}))
 
@@ -64,7 +56,7 @@ func pullImage(ctx context.Context, lgr logger, dc client.ImageAPIClient, imgNam
 	return nil
 }
 
-func runImage(ctx context.Context, lgr logger, dc client.ContainerAPIClient, imgName string,
+func runImage(ctx context.Context, lgr Logger, dc client.ContainerAPIClient, imgName string,
 	opts Options) (ContainerInfo, error) {
 	c := ContainerInfo{Name: genContainerName(), ImageName: imgName}
 	createResp, err := dc.ContainerCreate(ctx, &container.Config{
@@ -112,7 +104,7 @@ func runImage(ctx context.Context, lgr logger, dc client.ContainerAPIClient, img
 	return c, nil
 }
 
-func stopContainer(ctx context.Context, lgr logger, dc client.ContainerAPIClient, c ContainerInfo,
+func stopContainer(ctx context.Context, lgr Logger, dc client.ContainerAPIClient, c ContainerInfo,
 	logStdout, logStderr bool) {
 	if logStdout || logStderr {
 		if logs, err := dc.ContainerLogs(ctx, c.ID, types.ContainerLogsOptions{
@@ -146,7 +138,7 @@ func stopContainer(ctx context.Context, lgr logger, dc client.ContainerAPIClient
 	lgr.Log("Removed container:", c.String())
 }
 
-func waitContainerReady(ctx context.Context, lgr logger, c ContainerInfo,
+func waitContainerReady(ctx context.Context, lgr Logger, c ContainerInfo,
 	readyFunc func(context.Context, ContainerInfo) bool, readyTimeout time.Duration) bool {
 	if readyFunc == nil {
 		return true
@@ -176,50 +168,57 @@ func waitContainerReady(ctx context.Context, lgr logger, c ContainerInfo,
 
 // Run runs the given test function once the specified Docker image is running in a container
 func Run(t *testing.T, imgName string, opts Options, testFunc func(*testing.T, ContainerInfo)) {
-	RunT(t, imgName, opts, func(_ TestingT, containerInfo ContainerInfo) {
+	err := RunContext(context.Background(), t, imgName, opts, func(containerInfo ContainerInfo) error {
 		testFunc(t, containerInfo)
+		return nil
 	})
+	if err != nil {
+		t.Fatal("Failed to", err)
+	}
 }
 
-// RunT is the same as Run, but uses a testing.TB interface instead of testing.T.
-func RunT(t TestingT, imgName string, opts Options, testFunc func(TestingT, ContainerInfo)) {
+// RunContext is similar to Run, but takes a parent context and returns an error and doesn't rely on a testing.T.
+func RunContext(ctx context.Context, logger Logger, imgName string, opts Options, testFunc func(ContainerInfo) error) (retErr error) {
 	dc, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.41"))
 	if err != nil {
-		t.Fatal("Failed to get Docker client:", err)
+		return fmt.Errorf("get Docker client: %w", err)
 	}
 	defer func() {
-		if err := dc.Close(); err != nil {
-			t.Error("Failed to close Docker client:", err)
+		if err := dc.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("close Docker client: %w", err)
 		}
 	}()
 
 	opts.init()
-	pullCtx, pullTimeoutCancelFunc := context.WithTimeout(context.Background(), opts.PullTimeout)
+	pullCtx, pullTimeoutCancelFunc := context.WithTimeout(ctx, opts.PullTimeout)
 	defer pullTimeoutCancelFunc()
 
-	if err := pullImage(pullCtx, t, dc, imgName, opts.Platform); err != nil {
-		t.Fatal("Failed to pull image:", imgName, "error:", err)
+	if err := pullImage(pullCtx, logger, dc, imgName, opts.Platform); err != nil {
+		return fmt.Errorf("pull image: %v error: %w", imgName, err)
 	}
 
-	func() {
-		runCtx, runTimeoutCancelFunc := context.WithTimeout(context.Background(), opts.Timeout)
+	{
+		runCtx, runTimeoutCancelFunc := context.WithTimeout(ctx, opts.Timeout)
 		defer runTimeoutCancelFunc()
 
-		c, err := runImage(runCtx, t, dc, imgName, opts)
+		c, err := runImage(runCtx, logger, dc, imgName, opts)
 		if err != nil {
-			t.Fatal("Failed to run image:", imgName, "error:", err)
+			return fmt.Errorf("run image: %v error: %w", imgName, err)
 		}
 		defer func() {
-			stopCtx, stopTimeoutCancelFunc := context.WithTimeout(context.Background(), opts.CleanupTimeout)
+			stopCtx, stopTimeoutCancelFunc := context.WithTimeout(ctx, opts.CleanupTimeout)
 			defer stopTimeoutCancelFunc()
-			stopContainer(stopCtx, t, dc, c, opts.LogStdout, opts.LogStderr)
+			stopContainer(stopCtx, logger, dc, c, opts.LogStdout, opts.LogStderr)
 		}()
 
-		if waitContainerReady(runCtx, t, c, opts.ReadyFunc, opts.ReadyTimeout) {
-			testFunc(t, c)
+		if waitContainerReady(runCtx, logger, c, opts.ReadyFunc, opts.ReadyTimeout) {
+			if err := testFunc(c); err != nil {
+				return fmt.Errorf("run test func: %w", err)
+			}
 		} else {
-			t.Fatal("Container was never ready before timing out:", c.String())
+			retErr = fmt.Errorf("wait for container to get ready before timing out: %v", c.String())
 		}
-	}()
+	}
 
+	return retErr
 }

--- a/dktest_test.go
+++ b/dktest_test.go
@@ -6,14 +6,9 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
-)
 
-import (
-	"github.com/docker/go-connections/nat"
-)
-
-import (
 	"github.com/dhui/dktest"
+	"github.com/docker/go-connections/nat"
 )
 
 const (
@@ -49,6 +44,10 @@ func noop(*testing.T, dktest.ContainerInfo) {}
 
 func TestRun(t *testing.T) {
 	dktest.Run(t, testImage, dktest.Options{}, noop)
+}
+
+func TestRunTB(t *testing.T) {
+	dktest.RunT(t, testImage, dktest.Options{}, func(dktest.TestingT, dktest.ContainerInfo) {})
 }
 
 func TestRunParallel(t *testing.T) {

--- a/logger.go
+++ b/logger.go
@@ -1,5 +1,6 @@
 package dktest
 
-type logger interface {
+// Logger is the interface used to log messages.
+type Logger interface {
 	Log(...interface{})
 }


### PR DESCRIPTION
dktest requires a `*testing.T` which limits where it can be used to
tests. There are some cases where a `*testing.T` is not available in
tests, where it's still useful to start a container, examples:

 * In a benchmark, we have a `*testing.B`, yet we may want to start a
   container with some workload that is being benchmarked.
 * When a lot of tests want to share a container, `TestMain` can be used
   to start a container, and have all tests use that container.

One workaround is for callers to pass a dummy value like `&testing.T{}`,
but this can result in less visibility as logs/fatals can be lost
silently.

Instead, add a new method that accepts a context, and returns an error.
The existing `Run` method uses the new `RunContext` method and
reports any error using `t.Fatal`.