### PR TITLE
Expose ports Option

### DIFF
--- a/dktest.go
+++ b/dktest.go
@@ -68,13 +68,14 @@ func runImage(ctx context.Context, lgr Logger, dc client.ContainerAPIClient, img
 	opts Options) (ContainerInfo, error) {
 	c := ContainerInfo{Name: genContainerName(), ImageName: imgName}
 	createResp, err := dc.ContainerCreate(ctx, &container.Config{
-		Image:      imgName,
-		Labels:     map[string]string{label: "true"},
-		Env:        opts.env(),
-		Entrypoint: opts.Entrypoint,
-		Cmd:        opts.Cmd,
-		Volumes:    opts.volumes(),
-		Hostname:   opts.Hostname,
+		Image:        imgName,
+		Labels:       map[string]string{label: "true"},
+		Env:          opts.env(),
+		Entrypoint:   opts.Entrypoint,
+		Cmd:          opts.Cmd,
+		Volumes:      opts.volumes(),
+		Hostname:     opts.Hostname,
+		ExposedPorts: opts.ExposedPorts,
 	}, &container.HostConfig{
 		PublishAllPorts: true,
 		PortBindings:    opts.PortBindings,

--- a/options.go
+++ b/options.go
@@ -28,6 +28,7 @@ type Options struct {
 	Cmd          []string
 	// If you prefer to specify your port bindings as a string, use nat.ParsePortSpecs()
 	PortBindings nat.PortMap
+	ExposedPorts nat.PortSet
 	PortRequired bool
 	LogStdout    bool
 	LogStderr    bool


### PR DESCRIPTION
Needed to fix https://github.com/golang-migrate/migrate/pull/917

It looks like my issue there was the dockerfile for surrealdb does not expose ports, while most other images used in migrate tests do. This allows me to override that when creating the container.