### PR TITLE
Remove toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,5 +40,3 @@ require (
 )
 
 go 1.21
-
-toolchain go1.22.2


### PR DESCRIPTION
With go 1.21 the controversial toolchain directive got introduced which forces downstream consumers of libraries to needlessly change their go compiler version with no way to ignore it on an application level without go mod tidy and various tools and linters silently failing. I am of the opinion that libraries shouldn't really set a toolchain to allow consumers to be not bothered by it.