### PR TITLE
feat: pass registry auth option to `imagePull` func

### DIFF
--- a/dktest.go
+++ b/dktest.go
@@ -31,11 +31,14 @@ const (
 	label = "dktest"
 )
 
-func pullImage(ctx context.Context, lgr Logger, dc client.ImageAPIClient, imgName, platform string) error {
+func pullImage(ctx context.Context, lgr Logger, dc client.ImageAPIClient, registryAuth, imgName, platform string) error {
 	lgr.Log("Pulling image:", imgName)
 	// lgr.Log(dc.ImageList(ctx, types.ImageListOptions{All: true}))
 
-	resp, err := dc.ImagePull(ctx, imgName, image.PullOptions{Platform: platform})
+	resp, err := dc.ImagePull(ctx, imgName, image.PullOptions{
+		Platform:     platform,
+		RegistryAuth: registryAuth,
+	})
 	if err != nil {
 		return err
 	}
@@ -202,7 +205,7 @@ func RunContext(ctx context.Context, logger Logger, imgName string, opts Options
 	pullCtx, pullTimeoutCancelFunc := context.WithTimeout(ctx, opts.PullTimeout)
 	defer pullTimeoutCancelFunc()
 
-	if err := pullImage(pullCtx, logger, dc, imgName, opts.Platform); err != nil {
+	if err := pullImage(pullCtx, logger, dc, opts.PullRegistryAuth, imgName, opts.Platform); err != nil {
 		return fmt.Errorf("error pulling image: %v error: %w", imgName, err)
 	}
 

--- a/dktest_internal_test.go
+++ b/dktest_internal_test.go
@@ -63,7 +63,7 @@ func TestPullImage(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := tc.client
-			err := pullImage(ctx, t, &client, imageName, tc.platform)
+			err := pullImage(ctx, t, &client, "", imageName, tc.platform)
 			testErr(t, err, tc.expectErr)
 		})
 	}

--- a/options.go
+++ b/options.go
@@ -12,6 +12,8 @@ import (
 type Options struct {
 	// PullTimeout is the timeout used when pulling images
 	PullTimeout time.Duration
+	// PullRegistryAuth is the base64 encoded credentials for the registry
+	PullRegistryAuth string
 	// Timeout is the timeout used when starting a container and checking if it's ready
 	Timeout time.Duration
 	// ReadyTimeout is the timeout used for each container ready check.


### PR DESCRIPTION
This will enable users to use authed docker registries. An example for Google Cloud Artifact Registry:

```go
func Example_artifact_registry_auth() {
	dockerImageName := "us-docker.pkg.dev/GOOGLE_CLOUD_PROJECT/REGISTRY/image:latest"

	ctx := context.Background()

	// using github.com/google/go-containerregistry/pkg/v1/google
	authenticator, err := google.NewEnvAuthenticator(ctx)
	if err != nil {
		panic(err)
	}

	authConfig, err := authenticator.Authorization()
	if err != nil {
		panic(err)
	}

	authConfigJSON, err := authConfig.MarshalJSON()
	if err != nil {
		panic(err)
	}

	opts := dktest.Options{
		PortRequired:     true,
		ReadyFunc:        func(ctx context.Context, c dktest.ContainerInfo) bool { return true },
		LogStderr:        true,
		LogStdout:        true,
		PullRegistryAuth: base64.StdEncoding.EncodeToString(authConfigJSON),
	}

	dktest.Run(&testing.T{}, dockerImageName, opts, func(t *testing.T, c dktest.ContainerInfo) {})

	// Output:
}
```